### PR TITLE
ci: fix release-please ci failure to write label

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ name: release-please
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
`issues: write` permission is required for release-please to create labels on PRs